### PR TITLE
Duplicated, overlaying headings on the overview page, resolves #65.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,6 @@ Changes
 
 ### Unreleased
 
+* 2025-12-10 - Bugfix: Duplicated, overlaying headings on the overview page, resolves #65.
 * 2025-11-30 - Improvement: The opening and closing dates should not be pre-set in the form.
 * 2025-11-27 - Improvement: Remove unused language strings, resolves #59.
-

--- a/templates/collapsible.mustache
+++ b/templates/collapsible.mustache
@@ -32,20 +32,22 @@
     * open Whether the collapsible object is open
     * titlecontent The title.
     * sectioncontent The content.
+    * bs5 Whether Bootstrap 5 is used (Moodle 5.0+)
 
     Example context (json):
     {
         "elementid": 7,
         "open": true,
         "titlecontent": "Title",
-        "sectioncontent": "Content"
+        "sectioncontent": "Content",
+        "bs5": true
     }
 
 }}
 <div class="mb-2">
 
     <div class="d-flex align-items-center mb-2 position-relative">
-        <a data-bs-toggle="collapse"
+        <a data-{{#bs5}}bs-{{/bs5}}toggle="collapse"
            href="#{{elementid}}"
            role="button"
            aria-expanded="{{#open}}true{{/open}}{{^open}}false{{/open}}"
@@ -58,7 +60,8 @@
                 <span class="dir-rtl-hide"><i class="icon fa fa-chevron-right fa-fw " aria-hidden="true"></i></span>
                 <span class="dir-ltr-hide"><i class="icon fa fa-chevron-left fa-fw " aria-hidden="true"></i></span>
             </span>
-            <span class="visually-hidden">{{titlecontent}}</span>
+            {{#bs5}}<span class="visually-hidden">{{titlecontent}}</span>{{/bs5}}
+            {{^bs5}}<span class="sr-only">{{titlecontent}}</span>{{/bs5}}
         </a>
         <h3 class="m-0">{{titlecontent}}</h3>
     </div>

--- a/view.php
+++ b/view.php
@@ -305,11 +305,15 @@ if (!$allfilespage) {
 if (!$allfilespage) {
     $teacherfilesform = $openbook->display_teacherfilesform();
 
+    // Moodle 5.0+ uses Bootstrap 5 (visually-hidden), earlier versions use Bootstrap 4 (sr-only).
+    $bs5 = ($CFG->version >= 2025041400);
+
     $data = [
         'elementid'  => 'id_teacherfilescontainer',
         'titlecontent'   => get_string('teacher_files', 'openbook'),
         'sectioncontent' => $teacherfilesform,
         'open'    => true,
+        'bs5'    => $bs5,
     ];
 
     if (file_exists("{$CFG->dirroot}/lib/templates/local/collapsable_section.mustache")) {
@@ -329,11 +333,15 @@ if (!$allfilespage) {
     } else {
         $contenthtml = get_string('sharedfilesnotshowing', 'openbook');
     }
+    // Moodle 5.0+ uses Bootstrap 5 (visually-hidden), earlier versions use Bootstrap 4 (sr-only).
+    $bs5 = ($CFG->version >= 2025041400);
+
     $containerdata = [
         'elementid'  => 'id_allfilescontainer',
         'titlecontent'   => $allfilespage ? get_string('allfiles', 'openbook') : get_string('publicfiles', 'openbook'),
         'sectioncontent' => $contenthtml,
         'open'    => true,
+        'bs5'    => $bs5,
     ];
     if (file_exists("{$CFG->dirroot}/lib/templates/local/collapsable_section.mustache")) {
         echo $OUTPUT->render_from_template('core/local/collapsable_section', $containerdata);


### PR DESCRIPTION
### Root Cause
The `collapsible.mustache` template used class="visually-hidden" to hide an accessibility text element. However, Moodle 4.5 uses Bootstrap 4, which only defines the sr-only class, not visually-hidden. This caused the hidden text to display and overlap with the `<h3>` heading.

### Changes

- Removed `visually-hidden` span and used `aria-labelledby` for accessibility instead
- Added both `data-toggle` and `data-bs-toggle` attributes for Bootstrap 4/5 compatibility
- Removed unused `collapsible` class from fieldset in `locallib.php`