### PR TITLE
Activities block removal in 5.2 tackeled.

### DIFF
--- a/tests/behat/overview_report.feature
+++ b/tests/behat/overview_report.feature
@@ -35,12 +35,8 @@ Feature: Testing overview integration in openbook activity
 
   Scenario: The Openbook resource folder activity index redirect to the activities overview
     Given the site is running Moodle version 5.0 or higher
-    When I log in as "admin"
-    And I am on "Course 1" course homepage with editing mode on
-    And I add the "Activities" block
-    And I click on "Openbook resource folders" "link" in the "Activities" "block"
-    Then I should see "An overview of all activities in the course"
-    And I should see "Name" in the "openbook_overview_collapsible" "region"
+    When I am on the "C1" "course > activities > openbook" page logged in as "admin"
+    Then I should see "Name" in the "openbook_overview_collapsible" "region"
     And I should see "Upload until" in the "openbook_overview_collapsible" "region"
     And I should see "Students who submitted" in the "openbook_overview_collapsible" "region"
     And I should see "Actions" in the "openbook_overview_collapsible" "region"


### PR DESCRIPTION
According to https://moodle.atlassian.net/browse/MDL-86832 in Moodle 5.2, the activities block is about to get removed.

This copes with that removal to keep the Behat tests going.