### PR TITLE
Use override duedate for time remaining calculation, resolves #76

### DIFF
--- a/view.php
+++ b/view.php
@@ -236,10 +236,16 @@ $templatecontext->obtainstudentapproval = $openbookinstance->obtainstudentapprov
     ? get_string('obtainstudentapproval_yes', 'openbook')
     : get_string('obtainstudentapproval_no', 'openbook');
 
-if ($openbookinstance->duedate > 0) {
-    $timeremainingdiff = $openbookinstance->duedate - time();
+$effectiveduedate = $openbookinstance->duedate;
+$override = $openbook->override_get_currentuserorgroup();
+if ($override && $override->submissionoverride && $override->duedate > 0) {
+    $effectiveduedate = $override->duedate;
+}
+
+if ($effectiveduedate > 0) {
+    $timeremainingdiff = $effectiveduedate - time();
     if ($timeremainingdiff > 0) {
-        $templatecontext->timeremaining = format_time($openbookinstance->duedate - time());
+        $templatecontext->timeremaining = format_time($effectiveduedate - time());
     } else {
         $templatecontext->timeremaining = get_string('overdue', 'openbook');
     }


### PR DESCRIPTION
The "time remaining" message on the activity page was using the base activity's duedate, ignoring user overrides. Students with date overrides saw an incorrect countdown. Now uses the overridden duedate when available.