### PR TITLE
Show user identity fields on overrides page (fixes #89)

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -2233,10 +2233,6 @@ class openbook {
 
         $context->newoverrideurl = (new moodle_url($editurl, ['overrideid' => -1]))->out(false);
 
-        $overrides = $DB->get_records('openbook_overrides', ['openbook' => $this->instance->id]);
-        $context->overridesempty = count($overrides) == 0;
-        $context->overrides = [];
-
         // phpcs:disable moodle.Commenting.TodoComment
         // TODO: this has to be done in https://github.com/a-camacho/moodle-mod_openbook/issues/11
         $isgroupmode = false;
@@ -2250,6 +2246,36 @@ class openbook {
             $context->addoverridetitle = get_string('override:add:user', 'mod_openbook');
         }
 
+        // Identity fields driven by the site's "showuseridentity" policy — same mechanic as mod_quiz overrides.
+        $extrauserfields = [];
+        $context->identityheaders = [];
+        if (!$isgroupmode) {
+            $userfieldsapi = \core_user\fields::for_identity($this->context)->with_name()->with_userpic();
+            $extrauserfields = $userfieldsapi->get_required_fields([\core_user\fields::PURPOSE_IDENTITY]);
+            foreach ($extrauserfields as $field) {
+                $context->identityheaders[] = [
+                    'colclass' => 'col' . $field,
+                    'header'   => \core_user\fields::get_display_name($field),
+                ];
+            }
+        }
+
+        if ($isgroupmode) {
+            $overrides = $DB->get_records('openbook_overrides', ['openbook' => $this->instance->id]);
+        } else {
+            $userfieldssql = $userfieldsapi->get_sql('u', true, '', 'userid', false);
+            $overrides = $DB->get_records_sql("
+                    SELECT o.*, {$userfieldssql->selects}
+                      FROM {openbook_overrides} o
+                      JOIN {user} u ON o.userid = u.id
+                           {$userfieldssql->joins}
+                     WHERE o.openbook = :openbookid
+                     ORDER BY u.lastname, u.firstname",
+                    array_merge(['openbookid' => $this->instance->id], (array) $userfieldssql->params));
+        }
+        $context->overridesempty = count($overrides) == 0;
+        $context->overrides = [];
+
         $userurl = new moodle_url('/user/view.php', ['course' => $this->course->id]);
 
         if (!empty($overrides)) {
@@ -2257,11 +2283,15 @@ class openbook {
                 if ($isgroupmode) {
                     $group = $DB->get_record('groups', ['id' => $override->groupid]);
                     $override->fullname = $group->name;
+                    $override->identityvalues = [];
                 } else {
-                    $user = $DB->get_record('user', ['id' => $override->userid]);
-                    $override->fullname = fullname($user);
+                    $override->fullname = fullname($override);
                     $userurl->param('id', $override->userid);
                     $override->userurl = $userurl->out(false);
+                    $override->identityvalues = [];
+                    foreach ($extrauserfields as $field) {
+                        $override->identityvalues[] = ['value' => s($override->$field)];
+                    }
                 }
                 $override->editurl = (new moodle_url($editurl, ['overrideid' => $override->id]))->out(false);
                 $override->deleteurl = (new moodle_url($deleteurl, ['overrideid' => $override->id]))->out(false);

--- a/locallib.php
+++ b/locallib.php
@@ -2264,14 +2264,15 @@ class openbook {
             $overrides = $DB->get_records('openbook_overrides', ['openbook' => $this->instance->id]);
         } else {
             $userfieldssql = $userfieldsapi->get_sql('u', true, '', 'userid', false);
-            $overrides = $DB->get_records_sql("
-                    SELECT o.*, {$userfieldssql->selects}
-                      FROM {openbook_overrides} o
-                      JOIN {user} u ON o.userid = u.id
-                           {$userfieldssql->joins}
-                     WHERE o.openbook = :openbookid
-                     ORDER BY u.lastname, u.firstname",
-                    array_merge(['openbookid' => $this->instance->id], (array) $userfieldssql->params));
+            $overrides = $DB->get_records_sql(
+                "SELECT o.*, {$userfieldssql->selects}
+                   FROM {openbook_overrides} o
+                   JOIN {user} u ON o.userid = u.id
+                        {$userfieldssql->joins}
+                  WHERE o.openbook = :openbookid
+                  ORDER BY u.lastname, u.firstname",
+                array_merge(['openbookid' => $this->instance->id], (array) $userfieldssql->params)
+            );
         }
         $context->overridesempty = count($overrides) == 0;
         $context->overrides = [];

--- a/overrides_form.php
+++ b/overrides_form.php
@@ -56,12 +56,18 @@ class openbook_overrides_form extends moodleform {
         $mform->setType('groupid', PARAM_INT);
         $mform->setDefault('groupid', 0);
 
+        // Identity fields driven by the site's "showuseridentity" policy — same mechanic as mod_quiz overrides.
+        // for_identity() already enforces the policy and the viewer's moodle/site:viewuseridentity capability,
+        // so email (and any other configured field) only appears when the viewer is allowed to see it.
+        $userfieldsapi = \core_user\fields::for_identity($this->openbook->get_context())->with_name()->with_userpic();
+        $extrauserfields = $userfieldsapi->get_required_fields([\core_user\fields::PURPOSE_IDENTITY]);
+
         $usersclean = [];
         foreach ($users as $user) {
             if ($user->deleted == 1 || $user->suspended == 1) {
                 continue;
             }
-            $usersclean[$user->id] = fullname($user);
+            $usersclean[$user->id] = self::display_user_name($user, $extrauserfields);
         }
         $options = [
             'multiple' => false,
@@ -139,5 +145,41 @@ class openbook_overrides_form extends moodleform {
             );
         }
         $this->add_action_buttons(true);
+    }
+
+    /**
+     * Build a user's display label for the selection dropdown, appending the visible
+     * identity fields (e.g. email) in parentheses so the autocomplete can be searched by them.
+     *
+     * Mirrors mod_quiz's edit_override_form::display_user_name().
+     *
+     * @param stdClass $user a user record (with the standard identity columns loaded).
+     * @param array $extrauserfields identity fields from \core_user\fields::for_identity().
+     * @return string the full name, with any visible identity fields in parentheses.
+     */
+    private static function display_user_name(stdClass $user, array $extrauserfields): string {
+        global $CFG;
+
+        $username = fullname($user);
+        $namefields = [];
+        foreach ($extrauserfields as $field) {
+            if (strpos($field, 'profile_field_') === 0) {
+                // Custom profile field — load on demand (skipped entirely when none are configured).
+                if (!isset($user->profile)) {
+                    require_once($CFG->dirroot . '/user/profile/lib.php');
+                    profile_load_custom_fields($user);
+                }
+                $shortname = substr($field, strlen('profile_field_'));
+                if (isset($user->profile[$shortname]) && $user->profile[$shortname] !== '') {
+                    $namefields[] = s($user->profile[$shortname]);
+                }
+            } else if (isset($user->$field) && $user->$field !== '') {
+                $namefields[] = s($user->$field);
+            }
+        }
+        if ($namefields) {
+            $username .= ' (' . implode(', ', $namefields) . ')';
+        }
+        return $username;
     }
 }

--- a/templates/overrides.mustache
+++ b/templates/overrides.mustache
@@ -26,11 +26,19 @@
         "newoverrideurl": "https://example.com/mod/openbook/overrides_edit.php?add=1",
         "addoverridetitle": "Add new override",
         "usergroupcoltitle": "User / Group",
+        "identityheaders": [
+            { "colclass": "colemail", "header": "Email address" },
+            { "colclass": "colidnumber", "header": "ID number" }
+        ],
         "overridesempty": false,
         "overrides": [
             {
                 "userurl": "https://example.com/user/view.php?id=2",
                 "fullname": "Alice Dupont",
+                "identityvalues": [
+                    { "value": "alice@example.com" },
+                    { "value": "A12345" }
+                ],
                 "submissionoverride": "Submission deadline extended by 3 days",
                 "approvaloverride": "Requires approval from supervisor",
                 "editurl": "https://example.com/mod/openbook/overrides_edit.php?id=12",
@@ -39,6 +47,7 @@
             {
                 "userurl": "https://example.com/group/view.php?id=5",
                 "fullname": "Group A",
+                "identityvalues": [],
                 "submissionoverride": "Extended deadline",
                 "approvaloverride": "Auto-approved",
                 "editurl": "https://example.com/mod/openbook/overrides_edit.php?id=13",
@@ -53,6 +62,9 @@
         <thead>
             <tr>
                 <th>{{usergroupcoltitle}}</th>
+                {{#identityheaders}}
+                    <th class="{{colclass}}">{{header}}</th>
+                {{/identityheaders}}
                 <th>{{#str}}overrides,openbook{{/str}}</th>
                 <th>{{#str}}action{{/str}}</th>
             </tr>
@@ -67,6 +79,9 @@
                 {{#overrides}}
                     <tr>
                         <td>{{#userurl}}<a href="{{.}}" title="{{fullname}}">{{/userurl}}{{fullname}}{{#userurl}}</a>{{/userurl}}</td>
+                        {{#identityvalues}}
+                            <td>{{value}}</td>
+                        {{/identityvalues}}
                         <td><div class="">{{submissionoverride}}</div><div class="">{{approvaloverride}}</div>
                             <div class="">{{securewindowoverride}}</div></td>
                         <td><a href="{{editurl}}">{{#pix}}t/edit{{/pix}}</a><a href="{{deleteurl}}">{{#pix}}t/delete{{/pix}}</a></td>


### PR DESCRIPTION
Closes #89.

## Summary
- The activity overrides page previously showed only the user's full name; teachers with several students sharing a surname had no way to disambiguate. Now the page shows the same identity columns the site's "Show user identity" admin policy exposes (Email address by default, plus any of ID number, phone, etc. the admin enables).
- The mechanic mirrors core `mod_quiz/overrides.php`: identity fields are resolved via `\core_user\fields::for_identity()->with_name()->with_userpic()`, headers come from `\core_user\fields::get_display_name($field)`, and the override SELECT joins `{user}` once via `$userfieldssql` instead of running a `get_record('user', …)` per row.
- The disabled group-mode branch is untouched and renders an empty identity row safely.

## Files changed
- `locallib.php` — `overrides_export_for_template()` only.
- `templates/overrides.mustache` — header loop and per-row identity cells; example-context block refreshed.